### PR TITLE
Optimize kixi.stats.core/proportion

### DIFF
--- a/.github/workflows/cljs.yaml
+++ b/.github/workflows/cljs.yaml
@@ -28,13 +28,13 @@ jobs:
           node-version: '16'
 
       - name: Cache m2
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: m2-${{ hashFiles('deps.edn') }}
 
       - name: Cache gitlibs
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gitlibs
           key: gitlibs-${{ hashFiles('deps.edn') }}

--- a/.github/workflows/kondo.yaml
+++ b/.github/workflows/kondo.yaml
@@ -18,7 +18,7 @@ jobs:
           bb: latest
 
       - name: Cache kondo directory
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.clj-kondo/.cache
           key: ${{ runner.os }}-kondo

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,13 +22,13 @@ jobs:
           java-version: 17
 
       - name: Cache m2
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: m2-${{ hashFiles('deps.edn') }}
 
       - name: Cache gitlibs
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gitlibs
           key: gitlibs-${{ hashFiles('deps.edn') }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,13 +25,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache m2
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: m2-${{ hashFiles('deps.edn') }}
 
       - name: Cache gitlibs
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gitlibs
           key: gitlibs-${{ hashFiles('deps.edn') }}

--- a/src/kixi/stats/core.cljc
+++ b/src/kixi/stats/core.cljc
@@ -663,15 +663,21 @@
 (defn proportion
   "Calculate the proportion of inputs for which `pred` returns true."
   [pred]
-  (fn
-    ([] [0 0])
-    ([[n d] e]
-     (vector (cond-> n
-               (pred e) inc)
-             (inc d)))
-    ([[n d]]
-     (when (pos? d)
-       (double (/ n d))))))
+  (let [arrv (volatile! (long-array 2))]
+    (fn
+      ([] nil)
+      ([_ e]
+       (let [^longs arr @arrv]
+         (when (pred e)
+           (aset arr 0 (inc (aget arr 0))))
+         (aset arr 1 (inc (aget arr 1)))
+         (vreset! arrv arr)))
+      ([_]
+       (let [^longs arr @arrv
+             n (aget arr 0)
+             d (aget arr 1)]
+         (when (pos? d)
+           (double (/ n d))))))))
 
 (def share
   "Alias for proportion"


### PR DESCRIPTION
Current implementation uses vectors to keep the transitive state which allocates new vectors on each step. The proposed implementation uses a mutable array instead. Volatile is added to ensure that changes are visible between threads if somebody decides to uses this reducing function in a multi-threaded context.